### PR TITLE
Point to the correct net/html location

### DIFF
--- a/cleaner.go
+++ b/cleaner.go
@@ -1,13 +1,14 @@
 package goose
 
 import (
-	"code.google.com/p/go.net/html"
-	"code.google.com/p/go.net/html/atom"
 	"container/list"
-	"github.com/PuerkitoBio/goquery"
 	"log"
 	"regexp"
 	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
 )
 
 type cleaner struct {

--- a/extractor.go
+++ b/extractor.go
@@ -1,17 +1,18 @@
 package goose
 
 import (
-	"code.google.com/p/go.net/html"
-	"code.google.com/p/go.net/html/atom"
 	"container/list"
-	"github.com/PuerkitoBio/goquery"
-	"gopkg.in/fatih/set.v0"
 	"log"
 	"math"
 	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
+	"gopkg.in/fatih/set.v0"
 )
 
 const DEFAULT_LANGUAGE = "en"

--- a/outputformatter.go
+++ b/outputformatter.go
@@ -1,11 +1,12 @@
 package goose
 
 import (
-	"code.google.com/p/go.net/html"
-	"code.google.com/p/go.net/html/atom"
-	"github.com/PuerkitoBio/goquery"
 	"strconv"
 	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
 )
 
 type outputFormatter struct {

--- a/parser.go
+++ b/parser.go
@@ -1,8 +1,8 @@
 package goose
 
 import (
-	"code.google.com/p/go.net/html"
 	"github.com/PuerkitoBio/goquery"
+	"golang.org/x/net/html"
 )
 
 type parser struct{}


### PR DESCRIPTION
It seems code.google.com/p/go.net/html has changed to golang.org/x/net/html
