### PR TITLE
don't look for charset json asset

### DIFF
--- a/crawler.go
+++ b/crawler.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"code.google.com/p/go-charset/charset"
+	_ "code.google.com/p/go-charset/data"
 	"github.com/PuerkitoBio/goquery"
 )
 


### PR DESCRIPTION
this fix fixes an error message where go is looking for an asset that should be included by default