### PR TITLE
Feat/more meta extractors

### DIFF
--- a/extractor.go
+++ b/extractor.go
@@ -203,7 +203,7 @@ func (this *contentExtractor) getMetaDescription(article *Article) string {
 }
 
 //if the article has meta keywords set in the source, use that
-func (this *contentExtractor) getMetKeywords(article *Article) string {
+func (this *contentExtractor) getMetaKeywords(article *Article) string {
 	return this.getMetaContent(article, "keywords")
 }
 

--- a/extractor.go
+++ b/extractor.go
@@ -121,7 +121,7 @@ func (this *contentExtractor) getMetaLanguage(article *Article) string {
 	} else {
 		language = attr[0 : idx]
 	}
-	
+
 	_, ok := sw[language]
 
 	if language == "" || !ok {
@@ -130,7 +130,7 @@ func (this *contentExtractor) getMetaLanguage(article *Article) string {
 			language = DEFAULT_LANGUAGE
 		}
 	}
-	
+
 	this.config.targetLanguage = language
 	return language
 }
@@ -166,6 +166,12 @@ func (this *contentExtractor) getMetaContent(article *Article, metaName string) 
 		if exists && attr == metaName {
 			content, _ = s.Attr("content")
 			return false
+		} else {
+			attr, exists := s.Attr("itemprop")
+			if exists && attr == metaName {
+				content, _ = s.Attr("content")
+				return false
+			}
 		}
 		return true
 	})
@@ -199,6 +205,16 @@ func (this *contentExtractor) getMetaDescription(article *Article) string {
 //if the article has meta keywords set in the source, use that
 func (this *contentExtractor) getMetKeywords(article *Article) string {
 	return this.getMetaContent(article, "keywords")
+}
+
+//if the article has meta author set in the source, use that
+func (this *contentExtractor) getMetaAuthor(article *Article) string {
+	return this.getMetaContent(article, "author");
+}
+
+//if the article has meta content location set in the source, use that
+func (this *contentExtractor) getMetaContentLocation(article *Article) string {
+	return this.getMetaContent(article, "contentLocation");
 }
 
 //if the article has meta canonical link set in the url


### PR DESCRIPTION
part implementation for https://github.com/advancedlogic/GoOse/issues/2

Adds meta extractors for:
- `author`
- `contentLocation`

Improves:
- meta extracting by `itemprop` and `name` now.

```
<meta content="Matthew Chance and Holly Yan, CNN" itemprop="author" name="author"/>
<meta content="Moscow" itemprop="contentLocation"/>
```
reference: view-source:http://edition.cnn.com/2014/10/12/world/europe/russia-ukraine/index.html?eref=edition