### PR TITLE
Fixed: Rewritten code.google.com import to github version

### DIFF
--- a/crawler.go
+++ b/crawler.go
@@ -7,7 +7,7 @@ import (
 	"net/http/cookiejar"
 	"strings"
 
-	"code.google.com/p/go-charset/charset"
+	"github.com/rogpeppe/go-charset/charset"
 	"github.com/advancedlogic/goquery"
 )
 


### PR DESCRIPTION
Google Code (code.google.com) is shutting down, and `go get` is now giving warnings when using this package  (see https://github.com/sajari/docconv/issues/13).