### PR TITLE
Change crawl to return error instead of panicking.

### DIFF
--- a/crawler_test.go
+++ b/crawler_test.go
@@ -22,7 +22,10 @@ func ReadRawHTML(a Article) string {
 // ValidateArticle validates (test) the specified article
 func ValidateArticle(expected Article, removed *[]string) error {
 	g := New()
-	result := g.ExtractFromRawHTML(expected.FinalURL, ReadRawHTML(expected))
+	result, err := g.ExtractFromRawHTML(expected.FinalURL, ReadRawHTML(expected))
+	if err != nil {
+		return err
+	}
 
 	// DEBUG
 	//fmt.Printf("article := Article{\n\tDomain:          %q,\n\tTitle:           %q,\n\tMetaDescription: %q,\n\tCleanedText:     %q,\n\tMetaKeywords:    %q,\n\tCanonicalLink:   %q,\n\tTopImage:        %q,\n}\n\n", expected.Domain, result.Title, result.MetaDescription, result.CleanedText, result.MetaKeywords, result.CanonicalLink, result.TopImage)

--- a/goose.go
+++ b/goose.go
@@ -13,13 +13,13 @@ func New(args ...string) Goose {
 }
 
 // ExtractFromURL follows the URL, fetches the HTML page and returns an article object
-func (g Goose) ExtractFromURL(url string) *Article {
+func (g Goose) ExtractFromURL(url string) (*Article, error) {
 	cc := NewCrawler(g.config, url, "")
 	return cc.Crawl()
 }
 
 // ExtractFromRawHTML returns an article object from the raw HTML content
-func (g Goose) ExtractFromRawHTML(url string, RawHTML string) *Article {
+func (g Goose) ExtractFromRawHTML(url string, RawHTML string) (*Article, error) {
 	cc := NewCrawler(g.config, url, RawHTML)
 	return cc.Crawl()
 }


### PR DESCRIPTION
Panics are non-idiomatic[1]. This commit returns an error during `Crawl()`, instead of triggering a panic().

This PR passes the existing test suite. I will note, however, that I haven't tested this in production use yet.

[1] As per https://github.com/golang/go/wiki/CodeReviewComments#dont-panic