### PR TITLE
Add initialization of go-charset

### DIFF
--- a/crawler.go
+++ b/crawler.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/advancedlogic/goquery"
 	"github.com/rogpeppe/go-charset/charset"
+	_ "github.com/rogpeppe/go-charset/data"
 )
 
 // Crawler can fetch the target HTML page


### PR DESCRIPTION
The init function defined in the go-charset package must be called.
The following code causes a related bug.

```
$ cat test.go
package main

import (
        "github.com/advancedlogic/GoOse"
)

func main() {
        g := goose.New()
        url := "http://blog.livedoor.jp/unahide/archives/52966628.html"
        article, _ := g.ExtractFromURL(url)
        println("title", article.Title)
        println("description", article.MetaDescription)
        println("keywords", article.MetaKeywords)
        println("content", article.CleanedText)
        println("url", article.FinalURL)
        println("top image", article.TopImage)
}
$ go run test.go
charset: cannot open "charsets.json": open /usr/local/lib/go-charset/datafiles/charsets.json: no such file or directory
```