### PR TITLE
add Article.TitleUnmodified field & test

### DIFF
--- a/article.go
+++ b/article.go
@@ -10,6 +10,7 @@ import (
 // Article is a collection of properties extracted from the HTML body
 type Article struct {
 	Title           string             `json:"title,omitempty"`
+	TitleUnmodified string             `json:"titleunmodified,omitempty"`
 	CleanedText     string             `json:"content,omitempty"`
 	MetaDescription string             `json:"description,omitempty"`
 	MetaLang        string             `json:"lang,omitempty"`

--- a/crawler.go
+++ b/crawler.go
@@ -140,6 +140,7 @@ func (c Crawler) Crawl() (*Article, error) {
 	article.Doc = document
 
 	article.Title = extractor.GetTitle(document)
+	article.TitleUnmodified = extractor.getTitleUnmodified(document)
 	article.MetaLang = extractor.GetMetaLanguage(document)
 	article.MetaFavicon = extractor.GetFavicon(document)
 

--- a/extractor.go
+++ b/extractor.go
@@ -50,8 +50,8 @@ func NewExtractor(config Configuration) ContentExtractor {
 	}
 }
 
-// GetTitle returns the title set in the source, if the article has one
-func (extr *ContentExtractor) GetTitle(document *goquery.Document) string {
+//if the article has a title set in the source, use that
+func (extr *ContentExtractor) getTitleUnmodified(document *goquery.Document) string {
 	title := ""
 
 	titleElement := document.Find("title")
@@ -73,6 +73,12 @@ func (extr *ContentExtractor) GetTitle(document *goquery.Document) string {
 		}
 		title = titleElement.Text()
 	}
+	return title
+}
+
+// GetTitle returns the title set in the source, if the article has one
+func (extr *ContentExtractor) GetTitle(document *goquery.Document) string {
+	title := extr.getTitleUnmodified(document)
 
 	for _, delimiter := range titleDelimiters {
 		if strings.Contains(title, delimiter) {

--- a/extractor_test.go
+++ b/extractor_test.go
@@ -1,0 +1,30 @@
+package goose
+
+import (
+	"testing"
+)
+
+func Test_title(t *testing.T) {
+	titleUnmodified := "   foobar this - is it | bla ¿ "
+	title := "foobar this - is it"
+
+	c := NewCrawler(
+		GetDefaultConfiguration(),
+		"example.com",
+		"<!DOCTYPE html><html><head><title>" + 
+			titleUnmodified + "</title></head></html>")
+
+	a, err := c.Crawl()
+	if err != nil {
+		t.Error(err)
+	}
+	if (a.TitleUnmodified != titleUnmodified) {
+		t.Error("`" + titleUnmodified + "` is extracted as `" + a.TitleUnmodified + "`")
+	}
+
+	if (a.Title != title) {
+		t.Error("`" + a.Title + "` should be `" + title + "`")
+	}
+
+}
+


### PR DESCRIPTION
For when one wants to skip the title modification heuristics.
Also tests the title is actually extracted correctly, at least from the normal
`<title>` html tag.