### PR TITLE
use log.Println instead of fmt.Println

### DIFF
--- a/charset.go
+++ b/charset.go
@@ -1,7 +1,7 @@
 package goose
 
 import (
-	"fmt"
+	"log"
 	"strings"
 	"unicode/utf8"
 
@@ -56,7 +56,7 @@ func NormaliseCharset(characterSet string) string {
 func UTF8encode(raw string, sourceCharset string) string {
 	enc, name := charset.Lookup(sourceCharset)
 	if nil == enc {
-		fmt.Println("Cannot convert from", sourceCharset, ":", name)
+		log.Println("Cannot convert from", sourceCharset, ":", name)
 		return raw
 	}
 


### PR DESCRIPTION
charset.go uses `fmt.Println`. But in some cases, we don't want to send output to stdout. This PR modifies it to use `log.Println` instead of `fmt.Println`.