### PR TITLE
Detect charset when Content-Type contains text/xhtml

### DIFF
--- a/crawler.go
+++ b/crawler.go
@@ -31,12 +31,9 @@ func NewCrawler(config Configuration, url string, RawHTML string) Crawler {
 
 func getCharsetFromContentType(cs string) string {
 	cs = strings.ToLower(strings.Replace(cs, " ", "", -1))
-	if strings.HasPrefix(cs, "text/html;charset=") {
-		cs = strings.TrimPrefix(cs, "text/html;charset=")
-	}
-	if strings.HasPrefix(cs, "application/xhtml+xml;charset=") {
-		cs = strings.TrimPrefix(cs, "application/xhtml+xml;charset=")
-	}
+	cs = strings.TrimPrefix(cs, "text/html;charset=")
+	cs = strings.TrimPrefix(cs, "text/xhtml;charset=")
+	cs = strings.TrimPrefix(cs, "application/xhtml+xml;charset=")
 	return NormaliseCharset(cs)
 }
 


### PR DESCRIPTION
This PR adds the detection and removal of text/xhtml prefixes in Content-Type. This fixes the Context-Type detection and prevents that this message is printed when the prefix is text/xhtml `Cannot convert from TEXT/XHTML;CHARSET=UTF-8 : `

The `HasPrefix` checks are also not necessary. TrimPrefix will return the string unchanged in case it doesn't have the prefix.