### PR TITLE
Prevent from extracting the unmodified title twice

### DIFF
--- a/crawler.go
+++ b/crawler.go
@@ -125,8 +125,8 @@ func (c Crawler) Crawl(RawHTML string, url string) (*Article, error) {
 	article.FinalURL = url
 	article.Doc = document
 
-	article.Title = extractor.GetTitle(document)
 	article.TitleUnmodified = extractor.getTitleUnmodified(document)
+	article.Title = extractor.GetTitleFromUnmodifiedTitle(article.TitleUnmodified)
 	article.MetaLang = extractor.GetMetaLanguage(document)
 	article.MetaFavicon = extractor.GetFavicon(document)
 

--- a/extractor.go
+++ b/extractor.go
@@ -76,10 +76,8 @@ func (extr *ContentExtractor) getTitleUnmodified(document *goquery.Document) str
 	return title
 }
 
-// GetTitle returns the title set in the source, if the article has one
-func (extr *ContentExtractor) GetTitle(document *goquery.Document) string {
-	title := extr.getTitleUnmodified(document)
-
+// GetTitleFromUnmodifiedTitle returns the title from the unmodified one
+func (extr *ContentExtractor) GetTitleFromUnmodifiedTitle(title string) string {
 	for _, delimiter := range titleDelimiters {
 		if strings.Contains(title, delimiter) {
 			title = extr.splitTitle(strings.Split(title, delimiter))
@@ -94,6 +92,12 @@ func (extr *ContentExtractor) GetTitle(document *goquery.Document) string {
 	}
 
 	return strings.TrimSpace(title)
+}
+
+// GetTitle returns the title set in the source, if the article has one
+func (extr *ContentExtractor) GetTitle(document *goquery.Document) string {
+	title := extr.getTitleUnmodified(document)
+	return extr.GetTitleFromUnmodifiedTitle(title)
 }
 
 func (extr *ContentExtractor) splitTitle(titles []string) string {

--- a/extractor_test.go
+++ b/extractor_test.go
@@ -8,23 +8,19 @@ func Test_title(t *testing.T) {
 	titleUnmodified := "   foobar this - is it | bla ¿ "
 	title := "foobar this - is it"
 
-	c := NewCrawler(
-		GetDefaultConfiguration(),
-		"example.com",
-		"<!DOCTYPE html><html><head><title>" + 
-			titleUnmodified + "</title></head></html>")
+	c := NewCrawler(GetDefaultConfiguration())
 
-	a, err := c.Crawl()
+	a, err := c.Crawl("<!DOCTYPE html><html><head><title>"+
+		titleUnmodified+"</title></head></html>", "example.com")
 	if err != nil {
 		t.Error(err)
 	}
-	if (a.TitleUnmodified != titleUnmodified) {
+	if a.TitleUnmodified != titleUnmodified {
 		t.Error("`" + titleUnmodified + "` is extracted as `" + a.TitleUnmodified + "`")
 	}
 
-	if (a.Title != title) {
+	if a.Title != title {
 		t.Error("`" + a.Title + "` should be `" + title + "`")
 	}
 
 }
-


### PR DESCRIPTION
This PR prevents from extracting twice the unmodified title in the crawler. It also fixes extractor_test.