### PR TITLE
Fixed cleaner for theguardian.com & newyorker.com

### DIFF
--- a/cleaner.go
+++ b/cleaner.go
@@ -2,12 +2,13 @@ package goose
 
 import (
 	"container/list"
-	"github.com/PuerkitoBio/goquery"
-	"golang.org/x/net/html"
-	"golang.org/x/net/html/atom"
 	"log"
 	"regexp"
 	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
 )
 
 var whitelistedTextAtomTypes = []atom.Atom{atom.Span, atom.Em, atom.I, atom.Strong, atom.B, atom.P, atom.H1, atom.H2, atom.H3, atom.H4}
@@ -97,6 +98,9 @@ func collapseTextNodes(node *html.Node, collapsibleAtomTypes []atom.Atom) {
 var divToPElementsPattern = regexp.MustCompile("<(a|blockquote|dl|div|img|ol|p|pre|table|ul)")
 var tabsRegEx = regexp.MustCompile(`\t|^\s+$]`)
 var removeVisibilityStyleRegEx = regexp.MustCompile("visibility:[ ]*hidden|display:[ ]*none")
+var keepNodesRegEx = regexp.MustCompile(`\b(` +
+	`article` +
+	`)\b`)
 var removeNodesRegEx = regexp.MustCompile("" +
 	"[Cc]omentario|" +
 	"[Ff]ooter|" +
@@ -290,11 +294,10 @@ func (c *Cleaner) Clean(docToClean *goquery.Document) *goquery.Document {
 	docToClean = c.cleanEMTags(docToClean)
 	docToClean = c.dropCaps(docToClean)
 	docToClean = c.removeScriptsStyle(docToClean)
-	docToClean = c.cleanBadTags(docToClean, removeNodesRegEx, &[]string{"id", "class", "name"})
-	docToClean = c.cleanBadTags(docToClean, removeVisibilityStyleRegEx, &[]string{"style"})
+	docToClean = c.cleanBadTags(docToClean, keepNodesRegEx, removeNodesRegEx, &[]string{"id", "class", "name"})
+	docToClean = c.cleanBadTags(docToClean, nil, removeVisibilityStyleRegEx, &[]string{"style"})
 	docToClean = c.removeTags(docToClean, &[]string{"nav", "footer", "aside", "cite"})
 	docToClean = c.cleanParaSpans(docToClean)
-
 
 	docToClean = c.convertDivsToParagraphs(docToClean, "div")
 
@@ -415,7 +418,7 @@ func (c *Cleaner) removeScriptsStyle(doc *goquery.Document) *goquery.Document {
 	return doc
 }
 
-func (c *Cleaner) cleanBadTags(doc *goquery.Document, pattern *regexp.Regexp, selectors *[]string) *goquery.Document {
+func (c *Cleaner) cleanBadTags(doc *goquery.Document, keepPattern *regexp.Regexp, pattern *regexp.Regexp, selectors *[]string) *goquery.Document {
 	body := doc.Find("html")
 	children := body.Children()
 	children.Each(func(i int, s *goquery.Selection) {
@@ -424,9 +427,9 @@ func (c *Cleaner) cleanBadTags(doc *goquery.Document, pattern *regexp.Regexp, se
 			count := 0
 			naughtyList.Each(func(j int, node *goquery.Selection) {
 				attribute, _ := node.Attr(selector)
-				if pattern.MatchString(attribute) {
+				if (keepPattern == nil || !keepPattern.MatchString(attribute)) && pattern.MatchString(attribute) {
 					if c.config.debug {
-						log.Printf("Cleaning: Removing node with %s: %s\n", selector, c.config.parser.name(selector, node))
+						log.Printf("Cleaning: Removing node with %s: %s => matched %s\n", selector, c.config.parser.name(selector, node), strings.Join(pattern.FindAllString(attribute, 100), ", "))
 					}
 					c.config.parser.removeNode(node)
 					count++
@@ -541,15 +544,15 @@ func (c *Cleaner) convertDivsToParagraphs(doc *goquery.Document, domType string)
 			})
 
 			/*
-			newNode := new(html.Node)
-			newNode.Type = html.ElementNode
-			newNode.Data = strings.Join(replacementText, "")
-			newNode.DataAtom = atom.P
+				newNode := new(html.Node)
+				newNode.Type = html.ElementNode
+				newNode.Data = strings.Join(replacementText, "")
+				newNode.DataAtom = atom.P
 			*/
-/*
-			replacementText = strings.Replace(replacementText, "=C3=A8", "è")
-			replacementText = strings.Replace(replacementText, "=C3=A9", "é")
-*/
+			/*
+				replacementText = strings.Replace(replacementText, "=C3=A8", "è")
+				replacementText = strings.Replace(replacementText, "=C3=A9", "é")
+			*/
 			div.First().BeforeHtml("<p>" + strings.Join(replacementText, "") + "</p>")
 
 			for s := nodesToRemove.Front(); s != nil; s = s.Next() {


### PR DESCRIPTION
This fixes #69. The problem were the blacklists for

* `"commercial"` (theguarding.com uses "article-body-commercial-selector") and
* `"[_-]ad[s]?[_-]"` (newyorker.com uses the combination "page-hero-ad-hidden page--article")

Since the respective nodes also have an "article" class in them I added a whitelist to override the too broad blacklist. It's still just a heuristic and maybe the two blacklist rules should rather become more specific to identify real ads, though I'm not sure what would be reliable enough. For now, this fix works.