### PR TITLE
Fixed cleaner for eff.org

### DIFF
--- a/cleaner.go
+++ b/cleaner.go
@@ -99,7 +99,8 @@ var divToPElementsPattern = regexp.MustCompile("<(a|blockquote|dl|div|img|ol|p|p
 var tabsRegEx = regexp.MustCompile(`\t|^\s+$]`)
 var removeVisibilityStyleRegEx = regexp.MustCompile("visibility:[ ]*hidden|display:[ ]*none")
 var keepNodesRegEx = regexp.MustCompile(`\b(` +
-	`article` +
+	`article|` + // theguardian.com and newyorker.com (preventing match of "commercial" or "...-ad-...")
+	`field--label-hidden` + // eff.org (preventing match of "hidden")
 	`)\b`)
 var removeNodesRegEx = regexp.MustCompile("" +
 	"[Cc]omentario|" +


### PR DESCRIPTION
See this article, for example: https://www.eff.org/deeplinks/2021/08/eff-joins-global-coalition-asking-apple-ceo-tim-cook-stop-phone-scanning